### PR TITLE
added assertion for files paths starting with ~

### DIFF
--- a/src/petro/extractor/h264_extractor.cpp
+++ b/src/petro/extractor/h264_extractor.cpp
@@ -30,6 +30,8 @@ namespace extractor
         m_loop(loop),
         m_loop_offset(0)
     {
+        assert(std::string("~").compare(filename.substr(0,1)) != 0
+              && "You must provide a full file path");
         assert(m_file->is_open() && "Cannot open input file");
         assert(m_file->good() && "Invalid input file");
 


### PR DESCRIPTION
If the file path started with ~ (relative path) and by such activate the assert: https://github.com/steinwurf/petro/blob/fix_assertion_problem/src/petro/extractor/h264_extractor.cpp#L35 